### PR TITLE
Sample for Call notifications and In Call Notification

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -4,6 +4,8 @@
 Showcases how to pin widget within the app. Check the launcher widget menu for all the app widgets samples
 - [Audio Manager](connectivity/audio/src/main/java/com/example/platform/connectivity/audio/AudioSample.kt):
 This sample will show you how get all audio sources and set an audio device. Covers Bluetooth, LEA, Wired and internal speakers
+- [Call Notification Sample](connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt):
+Sample demonstrating how to make incoming call notifications and in call notifications
 - [Camera2 - Preview](camera/camera2/src/main/java/com/example/platform/camera/preview/Camera2Preview.kt):
 Demonstrates displaying processed pixel data directly from the camera sensor 
 - [Color Contrast](accessibility/src/main/java/com/example/platform/accessibility/ColorContrast.kt):

--- a/samples/connectivity/callnotification/README.md
+++ b/samples/connectivity/callnotification/README.md
@@ -1,0 +1,3 @@
+# CallNotificationSample samples
+
+// Sample for posting call and in call notifications

--- a/samples/connectivity/callnotification/README.md
+++ b/samples/connectivity/callnotification/README.md
@@ -1,3 +1,3 @@
 # CallNotificationSample samples
 
-// Sample for posting call and in call notifications
+// Sample for posting call and in call notifications. Calling notification have specific requirements such as style and priority https://developer.android.com/reference/android/app/Notification.CallStyle

--- a/samples/connectivity/callnotification/README.md
+++ b/samples/connectivity/callnotification/README.md
@@ -1,3 +1,3 @@
 # CallNotificationSample samples
 
-// Sample for posting call and in call notifications. Calling notification have specific requirements such as style and priority https://developer.android.com/reference/android/app/Notification.CallStyle
+Sample for posting call and in call notifications. Calling notification have specific requirements such as style and priority https://developer.android.com/reference/android/app/Notification.CallStyle

--- a/samples/connectivity/callnotification/build.gradle.kts
+++ b/samples/connectivity/callnotification/build.gradle.kts
@@ -1,0 +1,29 @@
+
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+plugins {
+    id("com.example.platform.sample")
+}
+
+android {
+    namespace = "com.example.platform.connectivity.callnotification"
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+}

--- a/samples/connectivity/callnotification/build.gradle.kts
+++ b/samples/connectivity/callnotification/build.gradle.kts
@@ -25,5 +25,4 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.10.1")
 }

--- a/samples/connectivity/callnotification/src/main/AndroidManifest.xml
+++ b/samples/connectivity/callnotification/src/main/AndroidManifest.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT"/>
+
+    <application>
+    <activity
+        android:name=".CallNotificationSample"
+        android:launchMode="singleTop"
+        android:exported="true">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+    </activity>
+
+    <receiver android:name=".CallNotificationSample$NotificationReceiver"
+        android:exported="false"/>
+    </application>
+</manifest>

--- a/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt
+++ b/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt
@@ -52,6 +52,7 @@ import com.google.android.catalog.framework.annotations.Sample
 @Sample(
     name = "Call Notification Sample",
     description = "Sample demonstrating how to make incoming call notifications and in call notifications",
+    documentation = "https://developer.android.com/reference/android/app/Notification.CallStyle"
 )
 class CallNotificationSample : ComponentActivity() {
 
@@ -104,7 +105,7 @@ class CallNotificationSample : ComponentActivity() {
                     else -> "Cancelled"
                 }
 
-                notificationSource.onCancelNotification()
+                notificationSource.cancelNotification()
 
                 //Using a toast message to keep example simple. We should be using a snackbar
                 //https://developer.android.com/jetpack/compose/layouts/material#snackbar
@@ -117,7 +118,7 @@ class CallNotificationSample : ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
 
-        notificationSource.onCancelNotification()
+        notificationSource.cancelNotification()
     }
 }
 

--- a/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt
+++ b/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt
@@ -55,7 +55,10 @@ import com.google.android.catalog.framework.annotations.Sample
 )
 class CallNotificationSample : ComponentActivity() {
 
-    var notificationSource: NotificationSource<NotificationReceiver>? = null
+    companion object {
+        lateinit var notificationSource: NotificationSource<NotificationReceiver>
+    }
+
 
     @OptIn(ExperimentalPermissionsApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -78,7 +81,7 @@ class CallNotificationSample : ComponentActivity() {
                     )
 
                     if (callPermission.status.isGranted) {
-                        EntryPoint(notificationSource!!)
+                        EntryPoint(notificationSource)
                     } else {
                         PermissionWidget(callPermission)
                     }
@@ -95,30 +98,23 @@ class CallNotificationSample : ComponentActivity() {
                     NotificationSource.Companion.NotificationState.CANCEL.ordinal,
                 )
 
-                var message = "No User Input"
-
-                when (notificationStateValue) {
-                    NotificationSource.Companion.NotificationState.ANSWER.ordinal -> message =
-                        "Answered"
-
-                    NotificationSource.Companion.NotificationState.REJECT.ordinal -> message =
-                        "Rejected"
-
-                    else -> {
-                        message =
-                            "Cancelled"
-                    }
+                val message = when (notificationStateValue) {
+                    NotificationSource.Companion.NotificationState.ANSWER.ordinal -> "Answered"
+                    NotificationSource.Companion.NotificationState.REJECT.ordinal -> "Rejected"
+                    else -> "Cancelled"
                 }
 
+                notificationSource.onCancelNotification()
                 Toast.makeText(context, message, Toast.LENGTH_LONG).show()
             }
         }
+
     }
 
     override fun onDestroy() {
         super.onDestroy()
 
-        notificationSource?.onCancelNotification()
+        notificationSource.onCancelNotification()
     }
 }
 

--- a/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt
+++ b/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.example.platform.connectivity.callnotification
+
+import android.Manifest
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionState
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+import com.google.accompanist.permissions.shouldShowRationale
+import com.google.android.catalog.framework.annotations.Sample
+
+@Sample(
+    name = "Call Notification Sample",
+    description = "Sample demonstrating how to make incoming call notifications and in call notifications",
+)
+class CallNotificationSample : ComponentActivity() {
+
+    var notificationSource: NotificationSource<NotificationReceiver>? = null
+
+    @OptIn(ExperimentalPermissionsApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        notificationSource = NotificationSource(this, NotificationReceiver::class.java)
+
+        setContent {
+            MaterialTheme {
+                // A surface container using the 'background' color from the theme
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = colorScheme.background,
+                ) {
+                    // We should be using make_own_call permissions but this requires
+                    // implementation of the telecom API to work correctly.
+                    // Please see telecom example for full implementation
+                    val callPermission = rememberPermissionState(
+                        Manifest.permission.POST_NOTIFICATIONS,
+                    )
+
+                    if (callPermission.status.isGranted) {
+                        EntryPoint(notificationSource!!)
+                    } else {
+                        PermissionWidget(callPermission)
+                    }
+                }
+            }
+        }
+    }
+
+    class NotificationReceiver : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            intent?.let {
+                val notificationStateValue = it.getIntExtra(
+                    NotificationSource.NOTIFICATION_ACTION,
+                    NotificationSource.Companion.NotificationState.CANCEL.ordinal,
+                )
+
+                var message = "No User Input"
+
+                when (notificationStateValue) {
+                    NotificationSource.Companion.NotificationState.ANSWER.ordinal -> message =
+                        "Answered"
+
+                    NotificationSource.Companion.NotificationState.REJECT.ordinal -> message =
+                        "Rejected"
+
+                    else -> {
+                        message =
+                            "Cancelled"
+                    }
+                }
+
+                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        notificationSource?.onCancelNotification()
+    }
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun PermissionWidget(permissionsState: PermissionState) {
+    var showRationale by remember(permissionsState) {
+        mutableStateOf(false)
+    }
+
+    if (showRationale) {
+        AlertDialog(
+            onDismissRequest = { showRationale = false },
+            title = {
+                Text(text = "")
+            },
+            text = {
+                Text(text = "")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        permissionsState.launchPermissionRequest()
+                    },
+                ) {
+                    Text("Continue")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showRationale = false
+                    },
+                ) {
+                    Text("Dismiss")
+                }
+            },
+        )
+    }
+
+    Button(
+        onClick = {
+            if (permissionsState.status.shouldShowRationale) {
+                showRationale = true
+            } else {
+                permissionsState.launchPermissionRequest()
+            }
+        },
+    ) {
+        Text(text = "Grant Permission")
+    }
+}
+
+@Composable
+fun EntryPoint(
+    notificationSource: NotificationSource<CallNotificationSample.NotificationReceiver>,
+) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Button(onClick = { notificationSource.postIncomingCall() }) {
+            Text("Post Incoming Call")
+        }
+        Button(onClick = { notificationSource.postOnGoingCall() }) {
+            Text("Post In Call")
+        }
+    }
+}

--- a/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt
+++ b/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/CallNotificationSample.kt
@@ -105,6 +105,9 @@ class CallNotificationSample : ComponentActivity() {
                 }
 
                 notificationSource.onCancelNotification()
+
+                //Using a toast message to keep example simple. We should be using a snackbar
+                //https://developer.android.com/jetpack/compose/layouts/material#snackbar
                 Toast.makeText(context, message, Toast.LENGTH_LONG).show()
             }
         }

--- a/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/NotificationSource.kt
+++ b/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/NotificationSource.kt
@@ -46,7 +46,7 @@ class NotificationSource<T>(
     companion object {
 
         const val ChannelId = "1234"
-
+        const val ChannelIntID = 1234
         /*
         Notification state sent via in intent to inform receiving broadcast what action the user wants to take
          */
@@ -120,21 +120,21 @@ class NotificationSource<T>(
      * Will post incoming call to sysUI
      */
     fun postIncomingCall() {
-        notificationManager.notify(1234, onCreateIncomingCallNotification())
+        notificationManager.notify(ChannelIntID, onCreateIncomingCallNotification())
     }
 
     /**
      * Posts an in call notification, if a notification has already been posted then it will update to a on going call notification
      */
     fun postOnGoingCall() {
-        notificationManager.notify(1234, onCreateIncallNotification())
+        notificationManager.notify(ChannelIntID, onCreateIncallNotification())
     }
 
     /**
      * Will cancel notification and dismiss from sysUI
      */
     fun onCancelNotification() {
-        notificationManager.cancel(1234)
+        notificationManager.cancel(ChannelIntID)
     }
 
     /**

--- a/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/NotificationSource.kt
+++ b/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/NotificationSource.kt
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.platform.connectivity.callnotification
+
+import android.R
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.media.AudioAttributes
+import android.media.AudioManager
+import android.media.RingtoneManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.PRIORITY_MAX
+import androidx.core.app.NotificationCompat.VISIBILITY_PUBLIC
+import androidx.core.app.Person
+import androidx.core.content.getSystemService
+
+/**
+ * Source for creating notifications and notification channels
+ */
+class NotificationSource<T>(
+    private val context: Context,
+    private val notificationBroadcastClass: Class<T>,
+) {
+
+    companion object {
+
+        const val ChannelId = "1234"
+
+        /*
+        Notification state sent via in intent to inform receiving broadcast what action the user wants to take
+         */
+        enum class NotificationState(val value: Int) {
+            ANSWER(0),
+            REJECT(1),
+            CANCEL(2),
+            CLEARED(3);
+
+            companion object {
+                fun valueOf(value: Int) = NotificationState.values().find { it.value == value }
+            }
+        }
+
+        //Get ringtone location
+        private val ringToneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
+        const val NOTIFICATION_ACTION = "NOTIFICATION_ACTION"
+
+        //Channel for on going call, this has low importance so that the notification is not always shown
+        @SuppressLint("NewApi")
+        val notificationChannelOngoing = NotificationChannel(
+            ChannelId, "Call Notifications",
+            NotificationManager.IMPORTANCE_LOW,
+        )
+
+        //Notification channel for incoming calls. Will play ringtone, will be no dismissible and will stay on screen until user interacts with notification.
+        @SuppressLint("NewApi")
+        fun notificationChannelIncoming(): NotificationChannel {
+            val notification = NotificationChannel(
+                ChannelId, "Call Notifications",
+                NotificationManager.IMPORTANCE_HIGH,
+            )
+            notification.importance = NotificationManager.IMPORTANCE_HIGH
+            notification.setSound(
+                ringToneUri,
+                AudioAttributes.Builder()
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .setLegacyStreamType(AudioManager.STREAM_RING)
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                    .build(),
+            )
+
+            return notification
+        }
+
+        @SuppressLint("NewApi")
+        var fakeCaller = Person.Builder()
+            .setName("Jane Doe")
+            .setImportant(true)
+            .build()
+    }
+
+    private val notificationManager = context.getSystemService<NotificationManager>()!!
+
+    //Intent and pending intent for full screen activity.
+    private val intent = Intent()
+        .setAction(Intent.ACTION_MAIN)
+        .setPackage(context.packageName)
+
+    private val pendingIntent =
+        PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+
+    init {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationManager.createNotificationChannel(notificationChannelIncoming())
+            notificationManager.createNotificationChannel(notificationChannelOngoing)
+        }
+    }
+
+    /**
+     * Will post incoming call to sysUI
+     */
+    fun postIncomingCall() {
+        notificationManager.notify(1234, onCreateIncomingCallNotification())
+    }
+
+    /**
+     * Posts an in call notification, if a notification has already been posted then it will update to a on going call notification
+     */
+    fun postOnGoingCall() {
+        notificationManager.notify(1234, onCreateIncallNotification())
+    }
+
+    /**
+     * Will cancel notification and dismiss from sysUI
+     */
+    fun onCancelNotification() {
+        notificationManager.cancel(1234)
+    }
+
+    /**
+     * Creates a notification for incoming calls.
+     * This notification plays a ringtone and is not dismissible
+     */
+    private fun onCreateIncomingCallNotification(): Notification {
+        val receiveCallIntent = Intent(context, notificationBroadcastClass)
+        receiveCallIntent.putExtra(NOTIFICATION_ACTION, NotificationState.ANSWER.ordinal)
+
+        val cancelCallIntent = Intent(context, notificationBroadcastClass)
+        cancelCallIntent.putExtra(NOTIFICATION_ACTION, NotificationState.REJECT.ordinal)
+
+        val receiveCallPendingIntent = PendingIntent.getBroadcast(
+            context, 1200,
+            receiveCallIntent, PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val cancelCallPendingIntent = PendingIntent.getBroadcast(
+            context, 1201,
+            cancelCallIntent, PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        return NotificationCompat.Builder(context, ChannelId)
+            .setSmallIcon(R.drawable.ic_dialog_dialer)
+            .setFullScreenIntent(pendingIntent, true)
+            .setSound(ringToneUri)
+            .setOngoing(true)
+            .setVisibility(VISIBILITY_PUBLIC)
+            .setPriority(PRIORITY_MAX)
+            .setStyle(
+                NotificationCompat.CallStyle.forIncomingCall(
+                    fakeCaller,
+                    cancelCallPendingIntent,
+                    receiveCallPendingIntent,
+                ),
+            )
+            .build()
+    }
+
+    /**
+     * Creates an in call notification which is hidden but shows the user the state of the call
+     */
+    private fun onCreateIncallNotification(): Notification {
+        val cancelCallIntent =
+            Intent(context, notificationBroadcastClass)
+        cancelCallIntent.putExtra("message", "Call Rejected")
+        cancelCallIntent.putExtra(NOTIFICATION_ACTION, NotificationState.CANCEL.ordinal)
+
+        val cancelCallPendingIntent = PendingIntent.getBroadcast(
+            context, 1201,
+            cancelCallIntent, PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        return NotificationCompat.Builder(context, ChannelId)
+            .setSmallIcon(R.drawable.ic_dialog_dialer)
+            .setFullScreenIntent(pendingIntent, false)
+            .setOngoing(true)
+            .setStyle(
+                NotificationCompat.CallStyle.forOngoingCall(
+                    fakeCaller,
+                    cancelCallPendingIntent,
+                ),
+            )
+            .build()
+    }
+}

--- a/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/NotificationSource.kt
+++ b/samples/connectivity/callnotification/src/main/java/com/example/platform/connectivity/callnotification/NotificationSource.kt
@@ -28,6 +28,7 @@ import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.RingtoneManager
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.PRIORITY_MAX
 import androidx.core.app.NotificationCompat.VISIBILITY_PUBLIC
@@ -65,14 +66,14 @@ class NotificationSource<T>(
         const val NOTIFICATION_ACTION = "NOTIFICATION_ACTION"
 
         //Channel for on going call, this has low importance so that the notification is not always shown
-        @SuppressLint("NewApi")
+        @RequiresApi(Build.VERSION_CODES.O)
         val notificationChannelOngoing = NotificationChannel(
             ChannelId, "Call Notifications",
             NotificationManager.IMPORTANCE_LOW,
         )
 
         //Notification channel for incoming calls. Will play ringtone, will be no dismissible and will stay on screen until user interacts with notification.
-        @SuppressLint("NewApi")
+        @RequiresApi(Build.VERSION_CODES.O)
         fun notificationChannelIncoming(): NotificationChannel {
             val notification = NotificationChannel(
                 ChannelId, "Call Notifications",
@@ -92,7 +93,7 @@ class NotificationSource<T>(
         }
 
         @SuppressLint("NewApi")
-        var fakeCaller = Person.Builder()
+        val fakeCaller = Person.Builder()
             .setName("Jane Doe")
             .setImportant(true)
             .build()


### PR DESCRIPTION
Sample on how to post in call notifications and incoming calls.

This sample has to use Post notification permission as the telecom stack is not implemented for posting notifications.