### PR TITLE
[Infra] - Update JavaLanguageVersion to 17 as Default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -73,11 +73,11 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,8 +56,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -23,7 +23,7 @@ group = "com.example.platform.plugin.buildlogic"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/build-logic/src/main/kotlin/com.example.platform.plugin/CommonConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com.example.platform.plugin/CommonConventionPlugin.kt
@@ -56,7 +56,7 @@ class CommonConventionPlugin : Plugin<Project> {
                     // Treat all Kotlin warnings as errors
                     allWarningsAsErrors = true
                     // Set JVM target to 11
-                    jvmTarget = "11"
+                    jvmTarget = "17"
                     // Allow use of @OptIn
                     freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
                     // Enable default methods in interfaces

--- a/build-logic/src/main/kotlin/com.example.platform.plugin/CommonConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com.example.platform.plugin/CommonConventionPlugin.kt
@@ -46,7 +46,7 @@ class CommonConventionPlugin : Plugin<Project> {
             pluginManager.withPlugin("java") {
                 extensions.configure<JavaPluginExtension> {
                     toolchain {
-                        it.languageVersion.set(JavaLanguageVersion.of(11 ))
+                        it.languageVersion.set(JavaLanguageVersion.of(17))
                     }
                 }
             }

--- a/build-logic/src/main/kotlin/com.example.platform.plugin/CommonConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com.example.platform.plugin/CommonConventionPlugin.kt
@@ -55,7 +55,7 @@ class CommonConventionPlugin : Plugin<Project> {
                 extensions.configure<KotlinJvmOptions> {
                     // Treat all Kotlin warnings as errors
                     allWarningsAsErrors = true
-                    // Set JVM target to 11
+                    // Set JVM target to 17
                     jvmTarget = "17"
                     // Allow use of @OptIn
                     freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"

--- a/build-logic/src/main/kotlin/com.example.platform.plugin/SamplePlugin.kt
+++ b/build-logic/src/main/kotlin/com.example.platform.plugin/SamplePlugin.kt
@@ -50,7 +50,7 @@ class SamplePlugin : Plugin<Project> {
             pluginManager.withPlugin("java") {
                 extensions.configure<JavaPluginExtension> {
                     toolchain {
-                        it.languageVersion.set(JavaLanguageVersion.of(11))
+                        it.languageVersion.set(JavaLanguageVersion.of(17))
                     }
                 }
             }

--- a/build-logic/src/main/kotlin/com.example.platform.plugin/SamplePlugin.kt
+++ b/build-logic/src/main/kotlin/com.example.platform.plugin/SamplePlugin.kt
@@ -58,7 +58,7 @@ class SamplePlugin : Plugin<Project> {
             // TODO: remove when KSP starts respecting the Java/Kotlin toolchain
             tasks.withType(KotlinCompile::class.java).configureEach {
                 it.kotlinOptions {
-                    jvmTarget = "11"
+                    jvmTarget = "17"
                 }
             }
 
@@ -73,8 +73,8 @@ class SamplePlugin : Plugin<Project> {
                     }
 
                     compileOptions {
-                        sourceCompatibility = JavaVersion.VERSION_11
-                        targetCompatibility = JavaVersion.VERSION_11
+                        sourceCompatibility = JavaVersion.VERSION_17
+                        targetCompatibility = JavaVersion.VERSION_17
                     }
 
                     buildFeatures {


### PR DESCRIPTION
# Description
This CL updates the default `JavaLanguageVersion` to 17.

The project was using an old version (`JavaLanguageVersion` = `11`) that doesn't come preinstalled on new systems as well as not installed on Android Studio Flamingo Patch 2.

This would make developers encounter this error:
<img width="990" alt="Screenshot 2023-07-07 at 2 19 50 PM" src="https://github.com/android/platform-samples/assets/5649571/d2b35bb4-8565-4f75-873a-3c83f9a06cb2">

The default of the latest Android Studio Version is 17 when freshly installed:
<img width="986" alt="Screenshot 2023-07-07 at 2 21 29 PM" src="https://github.com/android/platform-samples/assets/5649571/fd06c8bc-95b8-4140-9cd5-1bb5d52636ca">


# How Has This Been Tested?
Compile the `platform-samples` app to a devices as well as use a fresh install of Android Studio that will usually default point to jbt-17 (Jetbrains Runtime version 17.06) as of Android Studio Flamingo Patch 2

**Test Configuration #1 - Pixel 7 Pro API 34 Beta (Android 14 Beta)**

# Checklist:
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation