### PR TITLE
Add failed sample log in tests

### DIFF
--- a/app/src/androidTest/java/com/example/platform/app/NavigationTest.kt
+++ b/app/src/androidTest/java/com/example/platform/app/NavigationTest.kt
@@ -73,12 +73,16 @@ class NavigationTest {
             activity.catalogSamples.forEach {
                 // Skip disabled samples
                 if (Build.VERSION.SDK_INT >= it.minSDK) {
-                    scrollNode.performScrollToKey(it.route)
-                    onNode(hasText(it.name) and hasText(it.description)).performClick()
+                    try {
+                        scrollNode.performScrollToKey(it.route)
+                        onNode(hasText(it.name) and hasText(it.description)).performClick()
 
-                    // Go back
-                    Espresso.pressBack()
-                    platformLabel.assertIsDisplayed()
+                        // Go back
+                        Espresso.pressBack()
+                        platformLabel.assertIsDisplayed()
+                    } catch (e: Exception) {
+                        throw Exception("Test failed in sample ${it.name}", e)
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a sample fails it's not always easy to figure out which one. Catch the exception and rethrow it by adding the sample name.

Change-Id: I9ae17291dedb9cf05e7793251b49bdf600d22956