### PR TITLE
Target sample builds

### DIFF
--- a/app/src/androidTest/java/com/example/platform/app/NavigationTest.kt
+++ b/app/src/androidTest/java/com/example/platform/app/NavigationTest.kt
@@ -73,12 +73,16 @@ class NavigationTest {
             activity.catalogSamples.forEach {
                 // Skip disabled samples
                 if (Build.VERSION.SDK_INT >= it.minSDK) {
-                    scrollNode.performScrollToKey(it.route)
-                    onNode(hasText(it.name) and hasText(it.description)).performClick()
+                    try {
+                        scrollNode.performScrollToKey(it.route)
+                        onNode(hasText(it.name) and hasText(it.description)).performClick()
 
-                    // Go back
-                    Espresso.pressBack()
-                    platformLabel.assertIsDisplayed()
+                        // Go back
+                        Espresso.pressBack()
+                        platformLabel.assertIsDisplayed()
+                    } catch (e: Exception) {
+                        throw Exception("Test failed in sample ${it.name}", e)
+                    }
                 }
             }
         }


### PR DESCRIPTION
To enable test in isolation, you can declare in the local.properties one or more specific sample modules.

e.g target.samples=:samples:privacy:permissions

This will build the app with only the defined module. Useful for testing or providing apks with only the desired samples
