### PR TITLE
Add missing User Activity permission to Manifest

### DIFF
--- a/samples/location/src/main/AndroidManifest.xml
+++ b/samples/location/src/main/AndroidManifest.xml
@@ -19,4 +19,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission
+        android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION"
+        android:maxSdkVersion="28" />
 </manifest>


### PR DESCRIPTION
The permission was missing inside the manifest. Seems to work fine on <= 28 now.

Fixes #79