### PR TITLE
Upgrading Glance to 1.0.0 and AGP to 8.1.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ accompanist = "0.28.0"
 androidx-datastore = "1.0.0"
 androidx-navigation = "2.6.0"
 androidx-window = "1.1.0"
-agp = "8.1.0"
+agp = "8.1.1"
 casa = "0.4.3"
 coil = "2.3.0"
 ksp = "1.8.21-1.0.11"
@@ -117,8 +117,8 @@ play-services-location = { module = "com.google.android.gms:play-services-locati
 
 androidx-work-runtime-ktx = "androidx.work:work-runtime-ktx:2.8.1"
 androidx-core-remoteviews = "androidx.core:core-remoteviews:1.0.0-beta03"
-androidx-glance-appwidget = "androidx.glance:glance-appwidget:1.0.0-rc01"
-androidx-glance-material3 = "androidx.glance:glance-material3:1.0.0-rc01"
+androidx-glance-appwidget = "androidx.glance:glance-appwidget:1.0.0"
+androidx-glance-material3 = "androidx.glance:glance-material3:1.0.0"
 androidx-startup = 'androidx.startup:startup-runtime:1.1.1'
 androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 androidx-window-java = { module = "androidx.window:window-java", version.ref = "androidx-window" }


### PR DESCRIPTION
This PR upgrades the Glance Library from 1.0.0-rc to 1.0.0 final. As part of this AGPO was upgraded to 8.1.1 for compileSDK 34 support.

# Testing
 Using Android Studio, run the "App Widgets" module. Once the app is running, go to the home screen to add the widgets. Open the Widget picker by long pressing on the home screen and selecting "Widget", then select "platform samples". On this screen you can add the "Weather (Glance)" and "Glance todo list" widgets to your home screen.

See attached screenshot

![image](https://github.com/android/platform-samples/assets/2413816/bceac20b-17ce-4d99-9139-f8474a7c4f20)
