### PR TITLE
Fix corner radius for Glance app widget background

### DIFF
--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/GlanceKtx.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/GlanceKtx.kt
@@ -79,23 +79,19 @@ fun appWidgetBackgroundModifier() = GlanceModifier
     .background(GlanceTheme.colors.background)
     .appWidgetBackgroundCornerRadius()
 
-fun GlanceModifier.appWidgetBackgroundCornerRadius(): GlanceModifier {
+fun GlanceModifier.appWidgetBackgroundCornerRadius(): GlanceModifier =
     if (Build.VERSION.SDK_INT >= 31) {
         cornerRadius(android.R.dimen.system_app_widget_background_radius)
     } else {
         cornerRadius(16.dp)
     }
-    return this
-}
 
-fun GlanceModifier.appWidgetInnerCornerRadius(): GlanceModifier {
+fun GlanceModifier.appWidgetInnerCornerRadius(): GlanceModifier =
     if (Build.VERSION.SDK_INT >= 31) {
         cornerRadius(android.R.dimen.system_app_widget_inner_radius)
     } else {
         cornerRadius(8.dp)
     }
-    return this
-}
 
 @Composable
 fun stringResource(@StringRes id: Int, vararg args: Any): String {


### PR DESCRIPTION
The `cornerRadius` modifiers included in `appWidgetBackgroundCornerRadius()` and `appWidgetInnerCornerRadius()` where actually never applied to the widget. The `CombinedGlanceModifier` created by the `cornerRadius` functions was only ever created, but was never be made part of the modifier chain.

This can be seen by comparing the Glance widget (bottom) to the legacy one (on top), where the system's radius is applied correctly:
<img src="https://github.com/android/platform-samples/assets/1201850/b2f0c949-fe25-4ee6-82c7-dcb367982fc5" width="256" /> 


After the fix it will look like this:
<img src="https://github.com/android/platform-samples/assets/1201850/a2174cff-4215-4133-8968-84618f6dfbbd" width="256" /> 


Unfortunately the fix reveals a bug in Glance. If you select the widget by using a long press, you can see that the system still thinks that the smaller radius is applied. The small radius is probably the fallback radius of 16 dp.
I'll wait with the bug report until this PR is merged, so I can provide this project as a sample.

<img src="https://github.com/android/platform-samples/assets/1201850/b2f1fc90-07a8-4e77-b097-5b1ca88a5cfe" width="256" /> 