### PR TITLE
[Build] Reinforce the Gradle configuration for sample folder selection

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -57,7 +57,14 @@ if (samples.isEmpty()) {
         // Find all build.gradle files under samples folder
         settingsDir.walk()
             .filter { it.name == "build.gradle" || it.name == "build.gradle.kts" }
-            .filter { it.path.contains("${separator}samples${separator}") }
+            .filter {
+                val relativePath = if (it.isAbsolute) {
+                    it.path.substring(settingsDir.path.length)
+                } else {
+                    it.path
+                }
+                relativePath.contains("${separator}samples${separator}")
+            }
             .map { it.parent.substring(rootDir.path.length) }
             .forEach {
                 add(it.replace(separator, ":"))


### PR DESCRIPTION
## The problem
In the project, a folder walk is done to list all the "samples" folders. This is done by checking the path in the `settings.gradle.kts` file. 

The path provided in the filter logic can be absolute and in this case it can include parents folders names, which can corrupt the check.

### Example
My project is cloned in the following folder: `<user-home>/android/samples/platform-samples` Then all the folders will be considered as samples and the Gradle build will failed at configuration step.

Problem is reproduced on my configuration: macOS 12.6.2

## Solution
Remove the parents folders part in the path during the filtering if the path is absolute.