### PR TITLE
API_34 and above requires to use either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED flags

### DIFF
--- a/samples/location/src/main/java/com/example/platform/location/geofencing/GeofenceBroadcastReceiver.kt
+++ b/samples/location/src/main/java/com/example/platform/location/geofencing/GeofenceBroadcastReceiver.kt
@@ -18,8 +18,10 @@ package com.example.platform.location.geofencing
 
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -55,12 +57,16 @@ fun GeofenceBroadcastReceiver(
                         " Transition ${geofencingEvent.geofenceTransition}"
                 Log.d(
                     TAG,
-                    alertString
+                    alertString,
                 )
                 currentSystemOnEvent(alertString)
             }
         }
-        context.registerReceiver(broadcast, intentFilter)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            context.registerReceiver(broadcast, intentFilter, RECEIVER_NOT_EXPORTED)
+        } else {
+            context.registerReceiver(broadcast, intentFilter)
+        }
         onDispose {
             context.unregisterReceiver(broadcast)
         }


### PR DESCRIPTION
Location - Create and monitor Geofence sample crashes on API level 34 and above devices.

As per the [registerReceiver documentation](https://developer.android.com/reference/android/content/Context#registerReceiver(android.content.BroadcastReceiver,%20android.content.IntentFilter):~:text=createDeviceContext(int)-,registerReceiver,-Added%20in%20API) says:

> For apps targeting Build.VERSION_CODES.UPSIDE_DOWN_CAKE, either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED must be specified if the receiver is not being registered for system broadcasts or a SecurityException will be thrown. See registerReceiver(android.content.BroadcastReceiver, android.content.IntentFilter, int) to register a receiver with flags.

It is necessary to use one of these flags when targeting API_34 and above.

**Evidence:**

https://github.com/android/platform-samples/assets/94565457/9b708fda-5a5a-48a2-a086-4c225a01e122

**Exception:**

> java.lang.SecurityException: com.example.platform.app: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
                                                                                                    	at android.os.Parcel.createExceptionOrNull(Parcel.java:3057)
                                                                                                    	at android.os.Parcel.createException(Parcel.java:3041)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:3024)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:2966)
                                                                                                    	at 
