### PR TITLE
Include Glance android studio preview code samples to the layouts

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -126,6 +126,8 @@ play-services-location = { module = "com.google.android.gms:play-services-locati
 androidx-work-runtime-ktx = "androidx.work:work-runtime-ktx:2.9.0"
 androidx-core-remoteviews = "androidx.core:core-remoteviews:1.0.0"
 androidx-glance-appwidget = {group = "androidx.glance", name = "glance-appwidget", version.ref = "glance"}
+androidx-glance-preview = {group = "androidx.glance", name = "glance-preview", version.ref = "glance"}
+androidx-glance-appwidget-preview = {group = "androidx.glance", name = "glance-appwidget-preview", version.ref = "glance"}
 androidx-glance-material3 = {group = "androidx.glance", name = "glance-material3", version.ref = "glance"}
 androidx-graphics-core = { group = "androidx.graphics", name = "graphics-core", version = "1.0.0-beta01" }
 androidx-startup = 'androidx.startup:startup-runtime:1.1.1'

--- a/samples/user-interface/appwidgets/build.gradle.kts
+++ b/samples/user-interface/appwidgets/build.gradle.kts
@@ -36,4 +36,7 @@ dependencies {
     // Recommended to use WorkManager to load data for widgets
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.material)
+
+    debugImplementation(libs.androidx.glance.preview)
+    debugImplementation(libs.androidx.glance.appwidget.preview)
 }

--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/collections/layout/ActionListLayout.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/collections/layout/ActionListLayout.kt
@@ -11,6 +11,7 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
 import androidx.glance.LocalSize
 import androidx.glance.action.Action
 import androidx.glance.action.clickable
@@ -24,11 +25,15 @@ import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview
 import androidx.glance.semantics.contentDescription
 import androidx.glance.semantics.semantics
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import com.example.platform.ui.appwidgets.R
+import com.example.platform.ui.appwidgets.glance.layout.collections.data.FakeActionListDataRepository.Companion.demoData
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ActionListLayoutDimensions.circularCornerRadius
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ActionListLayoutDimensions.filledItemCornerRadius
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ActionListLayoutDimensions.filledItemPadding
@@ -42,6 +47,9 @@ import com.example.platform.ui.appwidgets.glance.layout.collections.layout.Actio
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ActionListLayoutSize.Large
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ActionListLayoutSize.Small
 import com.example.platform.ui.appwidgets.glance.layout.utils.ActionUtils.actionStartDemoActivity
+import com.example.platform.ui.appwidgets.glance.layout.utils.LargeWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.MediumWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.SmallWidgetPreview
 
 /**
  * A layout focused on presenting list of two-state actions represented by a title (1-2 words),
@@ -509,4 +517,44 @@ private object ActionListLayoutDimensions {
 
   /**  Corner radius to achieve circular shape. */
   val circularCornerRadius = 200.dp
+}
+
+/**
+ * Preview sizes for the widget covering the breakpoints.
+ *
+ * This allows verifying updates across multiple breakpoints.
+ */
+@OptIn(ExperimentalGlancePreviewApi::class)
+@Preview(widthDp = 259, heightDp = 200)
+@Preview(widthDp = 438, heightDp = 200)
+@Preview(widthDp = 644, heightDp = 200)
+private annotation class ActionListBreakpointPreviews
+
+/**
+ * Previews for the action list layout.
+ *
+ * First we look at the previews at defined breakpoints, tweaking them as necessary. In addition,
+ * the previews at standard sizes allows us to quickly verify updates across min / max and common
+ * widget sizes without needing to run the app or manually place the widget.
+ */
+@ActionListBreakpointPreviews
+@SmallWidgetPreview
+@MediumWidgetPreview
+@LargeWidgetPreview
+@Composable
+private fun ActionListLayoutPreview() {
+  val context = LocalContext.current
+
+  ActionListLayout(
+    title = context.getString(R.string.sample_action_list_app_widget_name),
+    titleIconRes = R.drawable.sample_home_icon,
+    titleBarActionIconRes = R.drawable.sample_power_settings_icon,
+    titleBarActionIconContentDescription = context.getString(
+      R.string.sample_action_list_settings_label
+    ),
+    titleBarAction = actionStartDemoActivity("Power settings title bar action"),
+    items = demoData,
+    checkedItems = listOf("1", "3"),
+    actionButtonClick = {},
+  )
 }

--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/collections/layout/CheckListLayout.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/collections/layout/CheckListLayout.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
 import androidx.glance.LocalSize
 import androidx.glance.action.Action
 import androidx.glance.appwidget.components.CircleIconButton
@@ -16,10 +17,13 @@ import androidx.glance.appwidget.components.TitleBar
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import com.example.platform.ui.appwidgets.R
+import com.example.platform.ui.appwidgets.glance.layout.collections.data.FakeCheckListDataRepository.Companion.demoData
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.CheckListLayoutDimensions.checkListRowStartPadding
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.CheckListLayoutDimensions.checkListRowEndPadding
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.CheckListLayoutDimensions.scaffoldHorizontalPadding
@@ -29,6 +33,9 @@ import com.example.platform.ui.appwidgets.glance.layout.collections.layout.Check
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.CheckListLayoutSize.Companion.showTitleBar
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.CheckListLayoutSize.Small
 import com.example.platform.ui.appwidgets.glance.layout.utils.ActionUtils.actionStartDemoActivity
+import com.example.platform.ui.appwidgets.glance.layout.utils.LargeWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.MediumWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.SmallWidgetPreview
 
 /**
  * A layout focused on presenting list of items in a check list. Content is displayed in a
@@ -410,4 +417,46 @@ private object CheckListLayoutDimensions {
   val checkListRowStartPadding = 2.dp
   // Padding to be applied on right of each item if there isn't a icon button on right.
   val checkListRowEndPadding = widgetPadding
+}
+
+/**
+ * Preview sizes of layout at the configured width breakpoints.
+ */
+@OptIn(ExperimentalGlancePreviewApi::class)
+@Preview(widthDp = 259, heightDp = 200)
+@Preview(widthDp = 303, heightDp = 200)
+@Preview(widthDp = 350, heightDp = 200)
+private annotation class CheckListBreakpointPreviews
+
+/**
+ * Previews for the check list layout.
+ *
+ * First we look at the previews at defined breakpoints, tweaking them as necessary. In addition,
+ * the previews at standard sizes allows us to quickly verify updates across min / max and common
+ * widget sizes without needing to run the app or manually place the widget.
+ */
+@CheckListBreakpointPreviews
+@SmallWidgetPreview
+@MediumWidgetPreview
+@LargeWidgetPreview
+@Composable
+private fun CheckListLayoutPreview() {
+  val context = LocalContext.current
+  CheckListLayout(
+    title = context.getString(R.string.sample_check_list_app_widget_name),
+    titleIconRes = R.drawable.sample_pin_icon,
+    titleBarActionIconRes = R.drawable.sample_add_icon,
+    titleBarActionIconContentDescription = context.getString(
+      R.string.sample_add_button_text,
+    ),
+    titleBarAction = actionStartDemoActivity("Add icon in title bar"),
+    items = demoData,
+    checkedItems = listOf("1"),
+    checkButtonContentDescription = context.getString(
+      R.string.sample_mark_done_button_content_description,
+    ),
+    checkedIconRes = R.drawable.sample_checked_circle_icon,
+    unCheckedIconRes = R.drawable.sample_circle_icon,
+    onCheck = {},
+  )
 }

--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/collections/layout/ImageGridLayout.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/collections/layout/ImageGridLayout.kt
@@ -10,6 +10,7 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
 import androidx.glance.LocalSize
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.components.CircleIconButton
@@ -22,6 +23,8 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
 import androidx.glance.layout.wrapContentHeight
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
@@ -36,6 +39,9 @@ import com.example.platform.ui.appwidgets.glance.layout.collections.layout.Image
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ImageGridLayoutSize.Medium
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ImageGridLayoutSize.Small
 import com.example.platform.ui.appwidgets.glance.layout.utils.ActionUtils
+import com.example.platform.ui.appwidgets.glance.layout.utils.LargeWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.MediumWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.SmallWidgetPreview
 
 /**
  * A layout focused on presenting a grid of images (with optional title and supporting text). The
@@ -295,4 +301,105 @@ private object ImageGridLayoutDimensions {
         else -> 1
       }
     }
+}
+
+/**
+ * Preview sizes for the widget covering the width based breakpoints of the image grid layout.
+ *
+ * This allows verifying updates across multiple breakpoints.
+ */
+@OptIn(ExperimentalGlancePreviewApi::class)
+@Preview(widthDp = 319, heightDp = 200)
+@Preview(widthDp = 321, heightDp = 200)
+@Preview(widthDp = 518, heightDp = 200)
+@Preview(widthDp = 520, heightDp = 200)
+private annotation class ImageGridBreakpointPreviews
+
+/**
+ * Previews for the image grid layout with both title and supporting text below the image
+ *
+ * First we look at the previews at defined breakpoints, tweaking them as necessary. In addition,
+ * the previews at standard sizes allows us to quickly verify updates across min / max and common
+ * widget sizes without needing to run the app or manually place the widget.
+ */
+@ImageGridBreakpointPreviews
+@SmallWidgetPreview
+@MediumWidgetPreview
+@LargeWidgetPreview
+@Composable
+private fun ImageTextGridLayoutPreview() {
+  val context = LocalContext.current
+
+  ImageGridLayout(
+    title = context.getString(R.string.sample_image_grid_app_widget_name),
+    titleIconRes = R.drawable.sample_grid_icon,
+    titleBarActionIconRes = R.drawable.sample_refresh_icon,
+    titleBarActionIconContentDescription = context.getString(
+      R.string.sample_refresh_icon_button_label
+    ),
+    titleBarAction = {},
+    items = listOf(
+      ImageGridItemData(
+        key = "0",
+        image = null, // placeholder
+        imageContentDescription = "A single water droplet rests in a budding red pansy.",
+        title = "A single water droplet rests in a budding red pansy.",
+        supportingText = "193 views"
+      ),
+      ImageGridItemData(
+        key = "1",
+        image = null, // placeholder
+        imageContentDescription = "A single water droplet rests in a budding red pansy.",
+        title = "A single water droplet rests in a budding red pansy.",
+        supportingText = "193 views"
+      ),
+      ImageGridItemData(
+        key = "2",
+        image = null, // placeholder
+        imageContentDescription = "Green plant, sky and flowers",
+        title = "Green plant, sky and flowers",
+        supportingText = "99,467 views"
+      ),
+      ImageGridItemData(
+        key = "3",
+        image = null, // placeholder
+        imageContentDescription = "A snow-shoer walking up Strelapass",
+        title = "A snow-shoer walking up Strelapass",
+        supportingText = "3,033 views"
+      )
+    )
+  )
+}
+
+/**
+ * Previews for the image grid layout with only images
+ *
+ * First we look at the previews at defined breakpoints, tweaking them as necessary. In addition,
+ * the previews at standard sizes allows us to quickly verify updates across min / max and common
+ * widget sizes without needing to run the app or manually place the widget.
+ */
+@ImageGridBreakpointPreviews
+@SmallWidgetPreview
+@MediumWidgetPreview
+@LargeWidgetPreview
+@Composable
+private fun ImageOnlyGridLayoutPreview() {
+  val context = LocalContext.current
+
+  ImageGridLayout(
+    title = context.getString(R.string.sample_image_grid_app_widget_name),
+    titleIconRes = R.drawable.sample_grid_icon,
+    titleBarActionIconRes = R.drawable.sample_refresh_icon,
+    titleBarActionIconContentDescription = context.getString(
+      R.string.sample_refresh_icon_button_label
+    ),
+    titleBarAction = {},
+    items = (0..5).map { index ->
+      ImageGridItemData(
+        key = "$index",
+        image = null, // placeholder
+        imageContentDescription = null,
+      )
+    }
+  )
 }

--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/collections/layout/ImageTextListLayout.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/collections/layout/ImageTextListLayout.kt
@@ -10,6 +10,7 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
 import androidx.glance.LocalSize
 import androidx.glance.action.Action
 import androidx.glance.appwidget.components.CircleIconButton
@@ -21,6 +22,8 @@ import androidx.glance.layout.ContentScale
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
@@ -37,6 +40,9 @@ import com.example.platform.ui.appwidgets.glance.layout.collections.layout.Image
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ImageTextListLayoutSize.Medium
 import com.example.platform.ui.appwidgets.glance.layout.collections.layout.ImageTextListLayoutSize.Small
 import com.example.platform.ui.appwidgets.glance.layout.utils.ActionUtils.actionStartDemoActivity
+import com.example.platform.ui.appwidgets.glance.layout.utils.LargeWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.MediumWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.SmallWidgetPreview
 
 /**
  * A layout focused on presenting a list of text with an image, and an optional icon button. The
@@ -422,4 +428,70 @@ private object Dimensions {
 
   /** Corner radius for image in each item. */
   val imageCornerRadius = 12.dp
+}
+
+/**
+ * Preview sizes for the widget covering the width based breakpoints of the image grid layout.
+ *
+ * This allows verifying updates across multiple breakpoints.
+ */
+@OptIn(ExperimentalGlancePreviewApi::class)
+@Preview(widthDp = 259, heightDp = 200)
+@Preview(widthDp = 261, heightDp = 200)
+@Preview(widthDp = 480, heightDp = 200)
+@Preview(widthDp = 644, heightDp = 200)
+private annotation class ImageTextListBreakpointPreviews
+
+/**
+ * Previews for the image grid layout with both title and supporting text below the image
+ *
+ * First we look at the previews at defined breakpoints, tweaking them as necessary. In addition,
+ * the previews at standard sizes allows us to quickly verify updates across min / max and common
+ * widget sizes without needing to run the app or manually place the widget.
+ */
+@ImageTextListBreakpointPreviews
+@SmallWidgetPreview
+@MediumWidgetPreview
+@LargeWidgetPreview
+@Composable
+private fun ImageTextListLayoutPreview() {
+  val context = LocalContext.current
+
+  ImageTextListLayout(
+    items = listOf(
+      ImageTextListItemData(
+        key = "0",
+        title = "Blossom, petal, flower",
+        supportingText = "23,815 views",
+        supportingImageBitmap = null // placeholder
+      ),
+      ImageTextListItemData(
+        key = "1",
+        title = "Orchids at New York Botanical Garden",
+        supportingText = "205,481 views",
+        supportingImageBitmap = null // placeholder
+      ),
+      ImageTextListItemData(
+        key = "2",
+        title = "Tabletop composition with flower",
+        supportingText = "85,060 views",
+        supportingImageBitmap = null // placeholder
+      ),
+      ImageTextListItemData(
+        key = "3",
+        title = "Wild bee on flower",
+        supportingText = "6,692 views ",
+        supportingImageBitmap = null // placeholder
+      )
+    ),
+    title = context.getString(
+      R.string.sample_text_and_image_list_app_widget_name
+    ),
+    titleIconRes = R.drawable.sample_image_icon,
+    titleBarActionIconRes = R.drawable.sample_refresh_icon,
+    titleBarActionIconContentDescription = context.getString(
+      R.string.sample_refresh_icon_button_label
+    ),
+    titleBarAction = {},
+  )
 }

--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/text/layout/LongTextLayout.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/text/layout/LongTextLayout.kt
@@ -39,10 +39,14 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.padding
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import com.example.platform.ui.appwidgets.R
 import com.example.platform.ui.appwidgets.glance.layout.text.layout.LongTextLayoutDimensions.captionFontSizeAndMaxLines
 import com.example.platform.ui.appwidgets.glance.layout.text.layout.LongTextLayoutDimensions.widgetPadding
 import com.example.platform.ui.appwidgets.glance.layout.text.layout.LongTextLayoutDimensions.primaryTextFontSizeAndMaxLines
+import com.example.platform.ui.appwidgets.glance.layout.utils.ActionUtils.actionStartDemoActivity
 import com.example.platform.ui.appwidgets.glance.layout.utils.FontUtils.calculateFontSizeAndMaxLines
+import com.example.platform.ui.appwidgets.glance.layout.utils.MediumWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.SmallWidgetPreview
 
 /**
  * A layout focused on presenting text only content.
@@ -270,4 +274,74 @@ private object LongTextLayoutDimensions {
     val captionMaxLines = 1 // Caption is always 1 line.
     return estimatedFontSize.coerceAtMost(maxCaptionFontSize.value).sp to captionMaxLines
   }
+}
+
+/**
+ * Previews of the long text layout with shorter caption and longer main text
+ *
+ * Previewing them at standard & min-max sizes allows us to adjust font sizes if needed. Use the
+ * Preview annotation to view the widget at specific width / height.
+ */
+@SmallWidgetPreview
+@MediumWidgetPreview
+@Composable
+private fun ShortCaptionSuperLongTextPreview() {
+  LongTextLayoutPreview(
+    text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet.",
+    caption = "Ut mollis",
+  )
+}
+
+
+/**
+ * Previews of the long text layout with longer caption and shorter main text
+ *
+ * Previewing them at standard & min-max sizes allows us to adjust font sizes if needed. Use the
+ * Preview annotation to view the widget at specific width / height.
+ */
+@SmallWidgetPreview
+@MediumWidgetPreview
+@Composable
+private fun LongCaptionShortTextPreview() {
+  LongTextLayoutPreview(
+    text = "Comparatively small text",
+    caption = "Ipsum faucibus ut mollis amet cursus",
+  )
+}
+
+/**
+ * Previews of the long text layout with medium sized caption and main text
+ *
+ * Previewing them at standard & min-max sizes allows us to adjust font sizes if needed. Use the
+ * Preview annotation to view the widget at specific width / height.
+ */
+@SmallWidgetPreview
+@MediumWidgetPreview
+@Composable
+private fun MediumTextPreview() {
+  LongTextLayoutPreview(
+    text = "This allows for a longer text string. Specifically because the focus in this, layout is on the primary text.",
+    caption = "Ut mollis amet cursus",
+  )
+}
+
+@Composable
+private fun LongTextLayoutPreview(text: String, caption: String) {
+  val context = LocalContext.current
+
+  LongTextLayout(
+    title = context.getString(R.string.sample_long_text_app_widget_name),
+    titleIconRes = R.drawable.sample_text_icon,
+    titleBarActionIconRes = R.drawable.sample_refresh_icon,
+    titleBarActionIconContentDescription = context.getString(
+      R.string.sample_refresh_icon_button_label
+    ),
+    titleBarAction = {},
+    data = LongTextLayoutData(
+      key = "1",
+      text = text,
+      caption = caption,
+    ),
+    action = actionStartDemoActivity("1"),
+  )
 }

--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/text/layout/TextWithImageLayout.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/text/layout/TextWithImageLayout.kt
@@ -50,6 +50,9 @@ import com.example.platform.ui.appwidgets.glance.layout.text.layout.TextWithImag
 import com.example.platform.ui.appwidgets.glance.layout.text.layout.TextWithImageLayoutTextStyles.secondaryTextFontValues
 import com.example.platform.ui.appwidgets.glance.layout.utils.ActionUtils.actionStartDemoActivity
 import com.example.platform.ui.appwidgets.glance.layout.utils.FontUtils
+import com.example.platform.ui.appwidgets.glance.layout.utils.LargeWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.MediumWidgetPreview
+import com.example.platform.ui.appwidgets.glance.layout.utils.SmallWidgetPreview
 
 /**
  * A layout focused on presenting a long text (~65 characters), its one line caption, a supporting
@@ -487,4 +490,31 @@ private object TextWithImageLayoutDimensions {
         height = size.height - titleBarHeight - widgetPadding
       )
     }
+}
+
+@SmallWidgetPreview
+@MediumWidgetPreview
+@LargeWidgetPreview
+@Composable
+private fun TextWithImagePreview() {
+  val context = LocalContext.current
+
+  TextWithImageLayout(
+    title = context.getString(R.string.sample_text_and_image_app_widget_name),
+    titleIconRes = R.drawable.sample_text_icon,
+    titleBarActionIconRes = R.drawable.sample_refresh_icon,
+    titleBarActionIconContentDescription = context.getString(
+      R.string.sample_refresh_icon_button_label
+    ),
+    titleBarAction = {},
+    data = TextWithImageData(
+      textData = TextData(
+        key = "1",
+        primary = "This allows for a longer text string.",
+        secondary = "Specifically because the focus in this, layout is on the primary text.",
+        caption = "Ut mollis amet cursus",
+      ),
+      imageData = ImageData()
+    )
+  )
 }

--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/utils/PreviewAnnotations.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/layout/utils/PreviewAnnotations.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.platform.ui.appwidgets.glance.layout.utils
+
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview
+
+/**
+ * Previews for 2x2 sized widgets in handheld and tablets.
+ *
+ * https://developer.android.com/design/ui/mobile/guides/widgets/sizing
+ */
+@OptIn(ExperimentalGlancePreviewApi::class)
+// Reference devices
+@Preview(widthDp = 172, heightDp = 234) // pixel 6a - smaller phone (2x2 in 4x5 grid - portrait)
+@Preview(widthDp = 172, heightDp = 224) // pixel 7 pro - larger phone (2x2 in 4x5 grid - portrait)
+@Preview(widthDp = 304, heightDp = 229) // Pixel tablet (2x2 in 6x5 grid - landscape)
+// Min / max sizes
+@Preview(widthDp = 109, heightDp = 115) // min handheld
+@Preview(widthDp = 306, heightDp = 276) // max handheld
+@Preview(widthDp = 180, heightDp = 184) // min tablet
+@Preview(widthDp = 304, heightDp = 304) // max tablet
+annotation class SmallWidgetPreview
+
+/**
+ * Previews for 4x2 handheld and 3x2 tablet widgets.
+ *
+ * https://developer.android.com/design/ui/mobile/guides/widgets/sizing
+ */
+@OptIn(ExperimentalGlancePreviewApi::class)
+// Reference devices
+@Preview(widthDp = 360, heightDp = 234) // pixel 6a - smaller phone (4x2 in 4x5 grid - portrait)
+@Preview(widthDp = 360, heightDp = 224) // pixel 7 pro - larger phone (4x2 in 4x5 grid - portrait)
+@Preview(widthDp = 488, heightDp = 229) // Pixel tablet (3x2 in 6x5 grid - landscape)
+// Min / max sizes
+@Preview(widthDp = 245, heightDp = 115) // min handheld
+@Preview(widthDp = 624, heightDp = 276) // max handheld
+@Preview(widthDp = 298, heightDp = 184) // min tablet
+@Preview(widthDp = 488, heightDp = 304) // max tablet
+annotation class MediumWidgetPreview
+
+/**
+ * Previews for 4x3 handheld and 3x3 tablet widgets.
+ *
+ * https://developer.android.com/design/ui/mobile/guides/widgets/sizing
+ */
+@OptIn(ExperimentalGlancePreviewApi::class)
+// Reference devices
+@Preview(widthDp = 360, heightDp = 359) // pixel 6a - smaller phone (4x3 in 4x5 grid - portrait)
+@Preview(widthDp = 360, heightDp = 344) // pixel 7 pro - larger phone (4x3 in 4x5 grid - portrait)
+@Preview(widthDp = 488, heightDp = 352) // Pixel tablet (3x3 in 6x5 grid - landscape)
+// Min / max sizes
+@Preview(widthDp = 245, heightDp = 185) // min handheld
+@Preview(widthDp = 624, heightDp = 422) // max handheld
+@Preview(widthDp = 298, heightDp = 424) // min tablet
+@Preview(widthDp = 488, heightDp = 672) // max tablet
+annotation class LargeWidgetPreview


### PR DESCRIPTION
Previews for Glance code is now supported via the `@Preview` annotation starting from Koala `2024.1.2` version.

https://developer.android.com/studio/preview/features#glance-widget-preview

In this PR, we provide example of how to use them to preview the breakpoints and standard widget sizes.

It uses the multi-preview approach to group preview annotations into custom semantic annotations.