### PR TITLE
Update Github actions to fix builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
           disk-size: 6000M
           heap-size: 600M
           script: ./gradlew connectedDebugAndroidTest --daemon
-          max_attempts: 3 # Accoun for flaky emulators
+          max_attempts: 3 # Account for flaky emulators
 
 
       - name: Upload test reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           disable-animations: true
           disk-size: 6000M
           heap-size: 600M
-          script: ./gradlew connectedDebugAndroidTest
+          script: ./gradlew connectedDebugAndroidTest --daemon
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 55
     strategy:
       matrix:
-        api-level: [34]
+        api-level: [30, 34]
 
     steps:
       - name: Delete unnecessary tools 🔧

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,19 +86,19 @@ jobs:
           ls /dev/kvm
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -109,8 +109,6 @@ jobs:
           disk-size: 6000M
           heap-size: 600M
           script: ./gradlew connectedDebugAndroidTest --daemon
-          max_attempts: 3 # Account for flaky emulators
-
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 55
     strategy:
       matrix:
-        api-level: [30, 34]
+        api-level: [34]
 
     steps:
       - name: Delete unnecessary tools 🔧

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 55
     strategy:
       matrix:
-        api-level: [26, 30]
+        api-level: [34]
 
     steps:
       - name: Checkout
@@ -81,6 +81,16 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+
+      - name: Run instrumentation tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          disable-animations: true
+          disk-size: 6000M
+          heap-size: 600M
+          script: ./gradlew connectedDebugAndroidTest
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,13 +60,31 @@ jobs:
 
   androidTest:
     needs: build
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    runs-on: ubuntu-latest
     timeout-minutes: 55
     strategy:
       matrix:
         api-level: [34]
 
     steps:
+      - name: Delete unnecessary tools 🔧
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: false # Don't remove Android tools
+          tool-cache: true # Remove image tool cache - rm -rf "$AGENT_TOOLSDIRECTORY"
+          dotnet: true # rm -rf /usr/share/dotnet
+          haskell: true # rm -rf /opt/ghc...
+          swap-storage: true # rm -f /mnt/swapfile (4GiB)
+          docker-images: false # Takes 16s, enable if needed in the future
+          large-packages: false # includes google-cloud-sdk and it's slow
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls /dev/kvm
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,16 +82,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Run instrumentation tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          arch: x86_64
-          disable-animations: true
-          disk-size: 6000M
-          heap-size: 600M
-          script: ./gradlew connectedDebugAndroidTest
-
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,8 @@ jobs:
           disk-size: 6000M
           heap-size: 600M
           script: ./gradlew connectedDebugAndroidTest --daemon
+          max_attempts: 3 # Accoun for flaky emulators
+
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Check lint
         run: ./gradlew lintDebug
 
-      - name: Build all build type and flavor permutations
-        run: ./gradlew assemble
+      - name: Build debug 
+        run: ./gradlew assembleDebug
 
       - name: Run local tests
         run: ./gradlew testDebug


### PR DESCRIPTION
- Build only debug builds instead of all build types and flavor permutations
- Run on ubuntu-latest instead of macOS-latest
- Build for api-level 34 instead of 26 and 30
- Add steps to delete unnecessary tools to free up disk space, and enable KVM group perms
- Add max of 3 retries to account for flaky emulator