### PR TITLE
Fix failing Ultra HDR sample on emulator

### DIFF
--- a/samples/graphics/ultrahdr/src/main/java/com/example/platform/graphics/ultrahdr/opengl/UltraHDRWithOpenGL.kt
+++ b/samples/graphics/ultrahdr/src/main/java/com/example/platform/graphics/ultrahdr/opengl/UltraHDRWithOpenGL.kt
@@ -182,8 +182,11 @@ class UltraHDRWithOpenGL : Fragment(),
     }
 
     override fun onAttach(context: Context) {
-        requireActivity().display
-            ?.registerHdrSdrRatioChangedListener(Runnable::run, updateHdrSdrRatio)
+        requireActivity().display?.let { display ->
+            if (display.isHdrSdrRatioAvailable) {
+                display.registerHdrSdrRatioChangedListener(Runnable::run, updateHdrSdrRatio)
+            }
+        }
         super.onAttach(context)
     }
 


### PR DESCRIPTION
Add UltraHDR capability check before registering a HDR/SDR ratio listener