### PR TITLE
Fix build crash issue due to sample failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 55
     strategy:
       matrix:
-        api-level: [34]
+        api-level: [35]
 
     steps:
       - name: Delete unnecessary tools 🔧

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 55
     strategy:
       matrix:
-        api-level: [35]
+        api-level: [34]
 
     steps:
       - name: Delete unnecessary tools 🔧

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,12 +30,12 @@ java {
 
 android {
     namespace = "com.example.platform.app"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.platform.app"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 buildscript {
     dependencies {
-        classpath("de.undercouch:gradle-download-task:4.1.2")
+        classpath(libs.gradle.download.task)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ androidx-window = "1.2.0"
 agp = "8.5.2"
 casa = "0.5.1"
 coil = "2.4.0"
+gradleDownloadTask = "4.1.2"
 ksp = "1.9.22-1.0.17"
 compose-bom = "2024.02.00"
 composeCompiler = "1.5.9"
@@ -96,6 +97,7 @@ coil-video = { module = "io.coil-kt:coil-video", version.ref = "coil" }
 
 google-ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 
+gradle-download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradleDownloadTask" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }

--- a/samples/graphics/ultrahdr/src/main/java/com/example/platform/graphics/ultrahdr/opengl/UltraHDRWithOpenGL.kt
+++ b/samples/graphics/ultrahdr/src/main/java/com/example/platform/graphics/ultrahdr/opengl/UltraHDRWithOpenGL.kt
@@ -70,7 +70,7 @@ class UltraHDRWithOpenGL : Fragment(),
         }
 
         companion object {
-            fun fromInt(value: Int) = ExtendedBrightnessValue.values().first { it.value == value }
+            fun fromInt(value: Int) = entries.first { it.value == value }
         }
     }
 


### PR DESCRIPTION
Creating a PR to fix the current issue where builds will consistently fail due to a specific samples GPU requirements.

This also updates the samples app to API 35