### PR TITLE
Update SamplePlugin to compile and target API 35

### DIFF
--- a/build-logic/src/main/kotlin/com.example.platform.plugin/SamplePlugin.kt
+++ b/build-logic/src/main/kotlin/com.example.platform.plugin/SamplePlugin.kt
@@ -64,11 +64,11 @@ class SamplePlugin : Plugin<Project> {
 
             pluginManager.withPlugin("com.android.library") {
                 configure<LibraryExtension> {
-                    compileSdk = 34
+                    compileSdk = 35
                     defaultConfig {
                         minSdk = 21
                         @Suppress("DEPRECATION")
-                        targetSdk = 34
+                        targetSdk = 35
                         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
                     }
 


### PR DESCRIPTION
This matches the behavior defined in the overall app's build: https://github.com/android/platform-samples/blob/main/app/build.gradle.kts#L33 and fixes the build failure in this PR: https://github.com/android/platform-samples/pull/209 since media3-1.5 requires API 35