### PR TITLE
Fix Glance app widget background corner radius

### DIFF
--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/GlanceKtx.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/GlanceKtx.kt
@@ -81,17 +81,19 @@ fun GlanceModifier.appWidgetBackgroundModifier(): GlanceModifier {
 }
 
 fun GlanceModifier.appWidgetBackgroundCornerRadius(): GlanceModifier {
-    if (Build.VERSION.SDK_INT >= 31) {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         cornerRadius(android.R.dimen.system_app_widget_background_radius)
+    } else {
+        this
     }
-    return cornerRadius(16.dp)
 }
 
 fun GlanceModifier.appWidgetInnerCornerRadius(): GlanceModifier {
-    if (Build.VERSION.SDK_INT >= 31) {
-        return cornerRadius(android.R.dimen.system_app_widget_inner_radius)
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        cornerRadius(android.R.dimen.system_app_widget_inner_radius)
+    } else {
+        this
     }
-    return cornerRadius(8.dp)
 }
 
 @Composable


### PR DESCRIPTION
The system corner radii (`system_app_widget_background_radius`,  `system_app_widget_inner_radius`) were previously never applied because of a missing return.

Also, the [docs of the `cornerRadius` modifier](https://developer.android.com/reference/kotlin/androidx/glance/GlanceModifier#(androidx.glance.GlanceModifier).cornerRadius(androidx.compose.ui.unit.Dp)) mention that it only works on SDK 31 and above, which allows us to simplify the corner radius modifiers a bit.

| Before | After |
|---|---|
| ![Screenshot_1737045668](https://github.com/user-attachments/assets/55ce95d3-3d73-4857-b6e3-76f83786e67c) | ![Screenshot_1737048129](https://github.com/user-attachments/assets/5957ef29-0118-4ae7-9045-8d6c50558b16) |

