### PR TITLE
Fixing Corner Radius Bug

### DIFF
--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/GlanceKtx.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/GlanceKtx.kt
@@ -81,17 +81,19 @@ fun GlanceModifier.appWidgetBackgroundModifier(): GlanceModifier {
 }
 
 fun GlanceModifier.appWidgetBackgroundCornerRadius(): GlanceModifier {
-    if (Build.VERSION.SDK_INT >= 31) {
+    return if (Build.VERSION.SDK_INT >= 31) {
         cornerRadius(android.R.dimen.system_app_widget_background_radius)
+    } else {
+        cornerRadius(16.dp)
     }
-    return cornerRadius(16.dp)
 }
 
 fun GlanceModifier.appWidgetInnerCornerRadius(): GlanceModifier {
-    if (Build.VERSION.SDK_INT >= 31) {
-        return cornerRadius(android.R.dimen.system_app_widget_inner_radius)
+    return if (Build.VERSION.SDK_INT >= 31) {
+         cornerRadius(android.R.dimen.system_app_widget_inner_radius)
+    } else {
+         cornerRadius(8.dp)
     }
-    return cornerRadius(8.dp)
 }
 
 @Composable


### PR DESCRIPTION
There is a bug in the system corner radius helper code for Glance that causes it to always return cornerRadius(16.dp) due to a missing else body.