### PR TITLE
Delete redundant code following build-logic removal

### DIFF
--- a/gradle/spotless-init.gradle.kts
+++ b/gradle/spotless-init.gradle.kts
@@ -29,10 +29,6 @@ initscript {
 }
 
 rootProject {
-    // We don't want to run it for the "build-logic" rootProject separately
-    if (this.name != "Platform Samples") {
-        return@rootProject
-    }
     apply<com.diffplug.gradle.spotless.SpotlessPlugin>()
     extensions.configure<com.diffplug.gradle.spotless.SpotlessExtension> {
         predeclareDeps()


### PR DESCRIPTION
This pull request deletes the code that has become redundant following the removal of the build-logic module.

Related Pull Request: https://github.com/android/platform-samples/pull/275