### PR TITLE
[Live Update] Fix: Correct color range for Color.valueOf

### DIFF
--- a/samples/user-interface/live-updates/src/main/java/com/example/platform/ui/live_updates/SnackbarNotificationManager.kt
+++ b/samples/user-interface/live-updates/src/main/java/com/example/platform/ui/live_updates/SnackbarNotificationManager.kt
@@ -142,8 +142,18 @@ object SnackbarNotificationManager {
 
         @RequiresApi(Build.VERSION_CODES.BAKLAVA)
         fun buildBaseProgressStyle(orderState: OrderState): ProgressStyle {
-            val pointColor = Color.valueOf(236f, 183f, 255f, 1f).toArgb()
-            val segmentColor = Color.valueOf(134f, 247f, 250f, 1f).toArgb()
+            val pointColor = Color.valueOf(
+                236f / 255f,
+                183f / 255f,
+                255f / 255f,
+                1f,
+            ).toArgb()
+            val segmentColor = Color.valueOf(
+                134f / 255f,
+                247f / 255f,
+                250f / 255f,
+                1f,
+            ).toArgb()
             var progressStyle = NotificationCompat.ProgressStyle()
                 .setProgressPoints(
                     listOf(

--- a/samples/user-interface/live-updates/src/main/java/com/example/platform/ui/live_updates/SnackbarNotificationManager.kt
+++ b/samples/user-interface/live-updates/src/main/java/com/example/platform/ui/live_updates/SnackbarNotificationManager.kt
@@ -149,9 +149,9 @@ object SnackbarNotificationManager {
                 1f,
             ).toArgb()
             val segmentColor = Color.valueOf(
-                134f / 255f,
-                247f / 255f,
-                250f / 255f,
+                134f / 255f, // Normalize red value to be between 0.0 and 1.0
+                247f / 255f, // Normalize green value to be between 0.0 and 1.0
+                250f / 255f, // Normalize blue value to be between 0.0 and 1.0
                 1f,
             ).toArgb()
             var progressStyle = NotificationCompat.ProgressStyle()

--- a/samples/user-interface/live-updates/src/main/java/com/example/platform/ui/live_updates/SnackbarNotificationManager.kt
+++ b/samples/user-interface/live-updates/src/main/java/com/example/platform/ui/live_updates/SnackbarNotificationManager.kt
@@ -143,9 +143,9 @@ object SnackbarNotificationManager {
         @RequiresApi(Build.VERSION_CODES.BAKLAVA)
         fun buildBaseProgressStyle(orderState: OrderState): ProgressStyle {
             val pointColor = Color.valueOf(
-                236f / 255f,
-                183f / 255f,
-                255f / 255f,
+                236f / 255f, // Normalize red value to be between 0.0 and 1.0
+                183f / 255f, // Normalize green value to be between 0.0 and 1.0
+                255f / 255f, // Normalize blue value to be between 0.0 and 1.0
                 1f,
             ).toArgb()
             val segmentColor = Color.valueOf(


### PR DESCRIPTION
## Description
This pull request addresses a bug in `SnackbarNotificationManager` where incorrect arguments were passed to the `Color.valueOf(r, g, b, a)` method.

The `Color.valueOf` method expects the red, green, and blue float components to be in the range of `0.0` to `1.0`. The previous implementation was incorrectly passing values in the 0-255 range, which caused the colors for the notification's `ProgressStyle` to be rendered incorrectly (likely clamped to the maximum value).

This change normalizes the RGB values by dividing them by 255f, ensuring the `pointColor` and `segmentColor` are created with the intended shades.

## Changes
Modified the `pointColor` and `segmentColor` value assignments in `buildBaseProgressStyle` to use normalized RGB values.

## Screenshot
Before | After
:---:  | :---:
![image](https://github.com/user-attachments/assets/e0097ac9-5992-4bd1-bde9-51c171742fcb) | ![image](https://github.com/user-attachments/assets/aaa0787f-0d42-4973-884e-3d3c89ed8bbd)


## How to test
1. Run the live-updates sample.
2. Trigger a notification that displays the `ProgressStyle`.
3. Verify that the colors of the progress points and segments now render correctly as per the intended RGB values.