### PR TITLE
Add share callback example

### DIFF
--- a/samples/user-interface/share/src/main/java/com/example/platform/ui/share/sender/ShareResultReceiver.kt
+++ b/samples/user-interface/share/src/main/java/com/example/platform/ui/share/sender/ShareResultReceiver.kt
@@ -20,9 +20,16 @@ import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.os.Build
+import android.service.chooser.ChooserResult
+import android.service.chooser.ChooserResult.CHOOSER_RESULT_COPY
+import android.service.chooser.ChooserResult.CHOOSER_RESULT_EDIT
+import android.service.chooser.ChooserResult.CHOOSER_RESULT_SELECTED_COMPONENT
+import android.service.chooser.ChooserResult.CHOOSER_RESULT_UNKNOWN
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.IntentCompat
+
 
 private const val TAG = "ShareResultReceiver"
 
@@ -30,13 +37,37 @@ private const val TAG = "ShareResultReceiver"
 class ShareResultReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
-        // This ComponentName represents the Activity that has received the data we shared.
-        val componentName: ComponentName? = IntentCompat.getParcelableExtra(
-            intent,
-            Intent.EXTRA_CHOSEN_COMPONENT,
-            ComponentName::class.java,
-        )
-        // ...
-        Log.d(TAG, "componentName: $componentName")
+        if (Build.VERSION.SDK_INT >= 35) {
+            val chooserResult: ChooserResult? = IntentCompat.getParcelableExtra(
+                intent,
+                Intent.EXTRA_CHOOSER_RESULT,
+                ChooserResult::class.java,
+            )
+            if (chooserResult != null) {
+                Log.i(TAG, "isShortcut: ${chooserResult.isShortcut}")
+                Log.i(TAG, "type: ${typeToString(chooserResult.type)}")
+                Log.i(TAG, "componentName: ${chooserResult.selectedComponent}")
+            } else {
+                Log.i(TAG, "chooserResult is null")
+            }
+        } else {
+            // This ComponentName represents the Activity that has received the data we shared.
+            val componentName: ComponentName? = IntentCompat.getParcelableExtra(
+                intent,
+                Intent.EXTRA_CHOSEN_COMPONENT,
+                ComponentName::class.java,
+            )
+            Log.d(TAG, "componentName: $componentName")
+        }
+    }
+
+    private fun typeToString(type: Int): String {
+        return when (type) {
+            CHOOSER_RESULT_SELECTED_COMPONENT -> "SELECTED_COMPONENT"
+            CHOOSER_RESULT_COPY -> "COPY"
+            CHOOSER_RESULT_EDIT -> "EDIT"
+            CHOOSER_RESULT_UNKNOWN -> "UNKNOWN"
+            else -> "UNKNOWN"
+        }
     }
 }

--- a/samples/user-interface/share/src/main/java/com/example/platform/ui/share/sender/ShareSender.kt
+++ b/samples/user-interface/share/src/main/java/com/example/platform/ui/share/sender/ShareSender.kt
@@ -52,7 +52,7 @@ fun ShareSender() {
     ) {
         val context = LocalContext.current
         Title(text = "Send various data")
-        ShareButton(text = "Share plain text") { sharePlainText(context) }
+        ShareButton(text = "Share plain text (Demonstrates share callback)") { sharePlainText(context) }
         ShareButton(text = "Share rich text") { shareRichText(context) }
         ShareButton(text = "Share image") { shareImage(context) }
         ShareButton(text = "Share multiple images") { shareMultipleImages(context) }
@@ -99,13 +99,30 @@ private val filenames = listOf(
     "night_highrise.jpg",
 )
 
+/**
+ * Shares a text message and demonstrates how to set up a BroadcastReceiver to be
+ * notified who has received the data we shared. See [ShareResultReceiver].
+ */
 private fun sharePlainText(context: Context) {
-    context.startActivity(
-        ShareCompat.IntentBuilder(context)
+    if (Build.VERSION.SDK_INT >= 22) {
+        val share = Intent(Intent.ACTION_SEND)
+        share.setType("text/plain")
+        share.putExtra(Intent.EXTRA_TEXT,"Hello, world!")
+        val pendingIntent = PendingIntent.getBroadcast(
+            context, 1234,
+            Intent(context, ShareResultReceiver::class.java),
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        context.startActivity(
+            Intent.createChooser(share, null, pendingIntent.intentSender)
+        )
+    } else {
+        context.startActivity(ShareCompat.IntentBuilder(context)
             .setType("text/plain")
             .setText("Hello, world!")
-            .createChooserIntent(),
-    )
+            .createChooserIntent()
+        )
+    }
 }
 
 private fun shareRichText(context: Context) {


### PR DESCRIPTION
Change-Id: I6cf5ce5174173c3134c2d29a9fb4f116616a492a

Use the ChooserResult object introduced in API Level 35 for demonstrating getting information on sharing

https://developer.android.com/training/sharing/send#share-interaction-data

The documentation will be updated w/ this new info.