### PR TITLE
Lint error supression

### DIFF
--- a/samples/user-interface/windowmanager/src/main/java/com/example/platform/ui/windowmanager/embedding/ExampleWindowInitializer.kt
+++ b/samples/user-interface/windowmanager/src/main/java/com/example/platform/ui/windowmanager/embedding/ExampleWindowInitializer.kt
@@ -15,6 +15,7 @@
  */
 
 package com.example.platform.ui.windowmanager.embedding
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.startup.Initializer
 import androidx.window.WindowSdkExtensions
@@ -53,6 +54,7 @@ class ExampleWindowInitializer : Initializer<RuleController> {
 
     private val mDemoActivityEmbeddingController = DemoActivityEmbeddingController.getInstance()
 
+    @SuppressLint("RequiresWindowSdk")
     override fun create(context: Context): RuleController {
         SplitController.getInstance(context).apply {
             if (WindowSdkExtensions.getInstance().extensionVersion >= 2) {


### PR DESCRIPTION
- Lint Suppression:
  * Added the `@SuppressLint("RequiresWindowSdk")` annotation to the `create` method in `ExampleWindowInitializer` to suppress false positive errors.