### PR TITLE
Add semantic coloring example from Android 17

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,12 +23,12 @@ plugins {
 
 android {
     namespace = "com.example.platform"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.platform"
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,8 +58,14 @@ org.gradle.java.installations.auto-download=false
 
 # Disable build features that are enabled by default,
 # https://developer.android.com/studio/releases/gradle-plugin#buildFeatures
-android.defaults.buildfeatures.buildconfig=false
-android.defaults.buildfeatures.aidl=false
-android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,7 +63,6 @@ android.defaults.buildfeatures.shaders=false
 android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
 android.enableAppCompileTimeRClass=false
 android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,6 +63,7 @@ android.defaults.buildfeatures.shaders=false
 android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
 android.enableAppCompileTimeRClass=false
 android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 [versions]
-agp = "8.13.2"
+agp = "9.1.1"
 fragmentCompose = "1.8.6"
-kotlin = "2.1.10"
+kotlin = "2.2.10"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/accessibility/build.gradle.kts
+++ b/samples/accessibility/build.gradle.kts
@@ -28,14 +28,25 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {
         viewBinding = true
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/camera/camera2/build.gradle.kts
+++ b/samples/camera/camera2/build.gradle.kts
@@ -26,13 +26,27 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 
-    viewBinding.isEnabled = true
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
+    }
 }
 
 dependencies {
@@ -53,4 +67,3 @@ dependencies {
     // Link to UltraHDR Graphics Samples
     implementation(project(mapOf("path" to ":samples:graphics:ultrahdr")))
 }
-

--- a/samples/camera/camerax/build.gradle.kts
+++ b/samples/camera/camerax/build.gradle.kts
@@ -28,8 +28,14 @@ android {
         minSdk = 21
         testOptions.targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 

--- a/samples/connectivity/UwbRanging/build.gradle.kts
+++ b/samples/connectivity/UwbRanging/build.gradle.kts
@@ -29,21 +29,29 @@ android {
 
     defaultConfig {
         minSdk = 31
-        targetSdk = 35
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+
     compileOptions {
-        sourceCompatibility(JavaVersion.VERSION_1_8)
-        targetCompatibility(JavaVersion.VERSION_1_8)
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
     sourceSets {
         getByName("main") {
             java.srcDirs("src/main/java", "src/main/proto")
         }
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/connectivity/audio/build.gradle.kts
+++ b/samples/connectivity/audio/build.gradle.kts
@@ -27,10 +27,21 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/connectivity/bluetooth/ble/build.gradle.kts
+++ b/samples/connectivity/bluetooth/ble/build.gradle.kts
@@ -27,10 +27,22 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/connectivity/bluetooth/companion/build.gradle.kts
+++ b/samples/connectivity/bluetooth/companion/build.gradle.kts
@@ -27,10 +27,21 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/connectivity/callnotification/build.gradle.kts
+++ b/samples/connectivity/callnotification/build.gradle.kts
@@ -28,10 +28,21 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/connectivity/telecom/build.gradle.kts
+++ b/samples/connectivity/telecom/build.gradle.kts
@@ -36,8 +36,14 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 

--- a/samples/graphics/pdf/build.gradle.kts
+++ b/samples/graphics/pdf/build.gradle.kts
@@ -28,10 +28,21 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/graphics/ultrahdr/build.gradle.kts
+++ b/samples/graphics/ultrahdr/build.gradle.kts
@@ -27,13 +27,27 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 
-    viewBinding.isEnabled = true
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
+    }
 }
 
 dependencies {

--- a/samples/location/build.gradle.kts
+++ b/samples/location/build.gradle.kts
@@ -26,10 +26,21 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/media/ultrahdr/build.gradle.kts
+++ b/samples/media/ultrahdr/build.gradle.kts
@@ -27,13 +27,27 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 
-    viewBinding.isEnabled = true
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
+    }
 }
 
 dependencies {

--- a/samples/media/video/build.gradle.kts
+++ b/samples/media/video/build.gradle.kts
@@ -27,16 +27,29 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 
-    viewBinding.isEnabled = true
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
 
     androidResources {
         noCompress += "tflite"
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/privacy/data/build.gradle.kts
+++ b/samples/privacy/data/build.gradle.kts
@@ -27,10 +27,22 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/privacy/permissions/build.gradle.kts
+++ b/samples/privacy/permissions/build.gradle.kts
@@ -26,10 +26,22 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/privacy/transparency/build.gradle.kts
+++ b/samples/privacy/transparency/build.gradle.kts
@@ -26,10 +26,19 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/storage/build.gradle.kts
+++ b/samples/storage/build.gradle.kts
@@ -28,10 +28,21 @@ android {
 
     defaultConfig {
         minSdk = 34
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/appwidgets/build.gradle.kts
+++ b/samples/user-interface/appwidgets/build.gradle.kts
@@ -27,14 +27,25 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {
         viewBinding = true
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/constraintlayout/build.gradle.kts
+++ b/samples/user-interface/constraintlayout/build.gradle.kts
@@ -25,14 +25,25 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {
         viewBinding = true
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/draganddrop/build.gradle.kts
+++ b/samples/user-interface/draganddrop/build.gradle.kts
@@ -25,14 +25,25 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {
         viewBinding = true
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/haptics/build.gradle.kts
+++ b/samples/user-interface/haptics/build.gradle.kts
@@ -26,10 +26,21 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/live-updates/build.gradle.kts
+++ b/samples/user-interface/live-updates/build.gradle.kts
@@ -6,18 +6,29 @@ plugins {
 
 android {
     namespace = "com.example.platform.ui.live_updates"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 36
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {
         viewBinding = true
+    }
+    lint {
+        targetSdk = 37
+    }
+    testOptions {
+        targetSdk = 37
     }
 }
 

--- a/samples/user-interface/live-updates/src/main/java/com/example/platform/ui/live_updates/SnackbarNotificationManager.kt
+++ b/samples/user-interface/live-updates/src/main/java/com/example/platform/ui/live_updates/SnackbarNotificationManager.kt
@@ -16,6 +16,7 @@
 
 package com.example.platform.ui.live_updates
 
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.NotificationManager.IMPORTANCE_DEFAULT
@@ -25,6 +26,7 @@ import android.graphics.Color
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.text.SpannableStringBuilder
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -51,9 +53,20 @@ object SnackbarNotificationManager {
         INITIALIZING(5000) {
             @RequiresApi(Build.VERSION_CODES.BAKLAVA)
             override fun buildNotification(): NotificationCompat.Builder {
+                val orderText = "Your order is being placed"
                 return buildBaseNotification(appContext, INITIALIZING)
                     .setSmallIcon(R.drawable.ic_launcher_foreground)
-                    .setContentTitle("You order is being placed")
+                    .setContentTitle(
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+                            SpannableStringBuilder().append(
+                                orderText,
+                                Notification.createSemanticStyleAnnotation(Notification.SEMANTIC_STYLE_INFO),
+                                0,
+                            )
+                        } else {
+                            orderText
+                        },
+                    )
                     .setContentText("Confirming with bakery...")
                     .setShortCriticalText("Placing")
                     .setStyle(buildBaseProgressStyle(INITIALIZING).setProgressIndeterminate(true))

--- a/samples/user-interface/picture-in-picture/build.gradle.kts
+++ b/samples/user-interface/picture-in-picture/build.gradle.kts
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2023 The Android Open Source Project
  *
@@ -28,15 +27,29 @@ android {
 
     defaultConfig {
         minSdk = 23
-        targetSdk = 35
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
-    viewBinding.isEnabled = true
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
+    }
 }
 
 dependencies {

--- a/samples/user-interface/predictiveback/build.gradle.kts
+++ b/samples/user-interface/predictiveback/build.gradle.kts
@@ -27,14 +27,25 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {
         viewBinding = true
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/quicksettings/build.gradle.kts
+++ b/samples/user-interface/quicksettings/build.gradle.kts
@@ -26,10 +26,22 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    lint {
         targetSdk = 36
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 36
     }
 }
 

--- a/samples/user-interface/share/build.gradle.kts
+++ b/samples/user-interface/share/build.gradle.kts
@@ -26,10 +26,22 @@ android {
 
     defaultConfig {
         minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    lint {
         targetSdk = 35
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/text/build.gradle.kts
+++ b/samples/user-interface/text/build.gradle.kts
@@ -26,14 +26,25 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {
         viewBinding = true
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/window-insets/build.gradle.kts
+++ b/samples/user-interface/window-insets/build.gradle.kts
@@ -26,14 +26,25 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 35
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {
         viewBinding = true
+    }
+    lint {
+        targetSdk = 35
+    }
+    testOptions {
+        targetSdk = 35
     }
 }
 

--- a/samples/user-interface/windowmanager/build.gradle.kts
+++ b/samples/user-interface/windowmanager/build.gradle.kts
@@ -27,8 +27,14 @@ android {
         minSdk = 24
         testOptions.targetSdk = 36
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     buildFeatures {


### PR DESCRIPTION
- Add semantic coloring API sample in Live Update sample
- update Live Updates and app sample SDK level to 37 to make use of Semantic Coloring APIs
- modify agp as it's needed to support SDK level 37
- update build.gradle.kt files to support new agp 9.0+ changes

I'll follow up with another refactoring of the build gradle files as there are changes in agp 9.0 dsl that deprecates things and needs migration.

See:
https://developer.android.com/build/migrate-to-built-in-kotlin#kts