### PR TITLE
Fix weather widget stuck in loading state

### DIFF
--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/weather/WeatherGlanceWidget.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/weather/WeatherGlanceWidget.kt
@@ -85,6 +85,7 @@ class WeatherGlanceWidget : GlanceAppWidget() {
 
     @RequiresApi(Build.VERSION_CODES.O)
     override suspend fun provideGlance(context: Context, id: GlanceId) {
+        WeatherRepo.updateWeatherInfo()
         provideContent { Content() }
     }
 

--- a/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/weather/WeatherGlanceWidgetReceiver.kt
+++ b/samples/user-interface/appwidgets/src/main/java/com/example/platform/ui/appwidgets/glance/weather/WeatherGlanceWidgetReceiver.kt
@@ -16,13 +16,9 @@
 
 package com.example.platform.ui.appwidgets.glance.weather
 
-import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 
 /**
@@ -33,12 +29,4 @@ import kotlinx.coroutines.launch
 @RequiresApi(Build.VERSION_CODES.O)
 class WeatherGlanceWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget = WeatherGlanceWidget()
-
-    override fun onEnabled(context: Context?) {
-        super.onEnabled(context)
-        CoroutineScope(Dispatchers.IO).launch {
-            WeatherRepo.updateWeatherInfo()
-        }
-    }
-
 }


### PR DESCRIPTION
## Summary

> **Testing note:** This change resolves the reported issue in the tested API 30 environment, but the issue still reproduces on API 37 and a physical Samsung device. The behavior in those environments may have a different cause and requires further investigation.

Investigates #402 — `WeatherGlanceWidget` gets stuck in the loading state (`WeatherInfo.Loading`) after following the "Always install with package manager" + "Launch: Nothing" run configuration from the sample's README.

## Root cause
`WeatherGlanceWidgetReceiver.onEnabled()` calls `WeatherRepo.updateWeatherInfo()` to populate the initial weather state. However, `onEnabled()` is only called once, when the number of widget instances for this provider goes from **0 to 1**.

When the app process is restarted while a widget instance already exists on the home screen, `onEnabled()` is not invoked again because the widget provider already has an active instance. The widget is still updated and rendered through the normal Glance update flow (`onUpdate` → `provideGlance`), but since `WeatherRepo`'s state is held in memory and resets on process restart, nothing re-triggers the data fetch — so the widget keeps rendering the `Loading` state it was left with.

This is confirmed by logcat: in the broken case, `WeatherRepo: updateWeatherInfo called` never appears, while `onUpdate` and `provideGlance` still run normally.

## Fix

Move the data-loading call out of the `Receiver` lifecycle callbacks and into `provideGlance()`, per the `GlanceAppWidget.provideGlance` documentation:

> "This is a good place to load any data needed to render the Composable. Use `provideContent` to provide the Composable once the data is ready."

```kotlin
override suspend fun provideGlance(context: Context, id: GlanceId) {
    WeatherRepo.updateWeatherInfo()
    provideContent { Content() }
}
```

- Removed the `CoroutineScope(Dispatchers.IO).launch { WeatherRepo.updateWeatherInfo() }` calls from `onEnabled()` and `onUpdate()`.
- `provideGlance()` provides the appropriate entry point to load data required to render the widget before calling `provideContent()`.
- `WeatherRepo.updateWeatherInfo()` already has its own throttling (`mutex` + `lastRun`/`TIMEOUT`), preventing redundant updates when multiple widget instances trigger the call.

## Testing

On a Pixel 7 emulator running API 30 (Android 11), I reproduced the bug using the run configuration described in the sample's README (Always install with package manager + Launch: Nothing). Logcat confirmed that `updateWeatherInfo` was never called and the widget stayed in `Loading`.

After the fix, on the same environment, I verified across multiple runs that:
- `provideGlance` → `updateWeatherInfo()` → `provideContent` executes correctly on every relaunch, without requiring a resize.
- The widget transitions from `Loading` to `Available` as expected.
- No duplicate fetches occur across different widget sizes (throttling confirmed via `updateWeatherInfo - throttled (too soon)` logs).

## Note

I also tested the fix on API 37 (Android 16) and on a physical Samsung device. In both environments, the issue still reproduces. Further investigation is needed to determine whether the issue has a different cause in these environments.